### PR TITLE
Change the dbconnect Redshift user group

### DIFF
--- a/R/aws.R
+++ b/R/aws.R
@@ -67,7 +67,7 @@ aws_get_credentials <- function(user){
     '--profile', 'dbconnect',  'redshift', 'get-cluster-credentials',
     '--cluster-identifier', 'datalake-redshift-public-prod',
     '--db-user', user, '--auto-create', '--db-groups',  'iam',
-    'readonlyusers'
+    'readonly_dbconnect'
   )
   creds <- system2(cmd, args, stdout = TRUE)
   jsonlite::fromJSON(creds)


### PR DESCRIPTION
When a user connected with Datacampr/DBconnect, a new user was created on Redshift and added to the `readonlyusers` group.
In this PR, we change the users' group to `readonly_dbconnect`. The `readonly_dbconnect` is added to the Redshift's shortquery/fast queue. It should improve morning performance in Belgium/UK for queries issued by a user via DatacampR