### PR TITLE
[CT-1281] Add possibility to use environment variables for the credentials

### DIFF
--- a/R/creds.R
+++ b/R/creds.R
@@ -22,7 +22,7 @@ get_creds <- function(dbname = "main-app", cache = FALSE, cache_folder = "~/.dat
   return(creds)
 }
 
-fields <- c(user = "user", password = "password", host = "endpoint", port = "port", drv = "type")
+cred_fields <- c(user = "user", password = "password", host = "endpoint", port = "port", drv = "type")
 
 fetch_creds <- function(dbname = "main-app", ...) {
   print("Fetching credentials...")
@@ -30,9 +30,9 @@ fetch_creds <- function(dbname = "main-app", ...) {
   # May be worth having a database-level parameter that lists all the parameters
 
   if (stringr::str_detect(dbname, "athena")) {
-    fields <- c(fields, s3_staging = "s3-staging")
+    fields <- c(cred_fields, s3_staging = "s3-staging")
   } else {
-    fields <- c(fields, dbname = "database")
+    fields <- c(cred_fields, dbname = "database")
   }
 
   names <- paste("/dbconnect", dbname, fields, sep = "/")
@@ -67,22 +67,17 @@ get_env_overwrite <- function(key, value) {
     return(value)
   }
 
-  # Use fields list to create environment variable (e.g. DBCONNECT_ENDPOINT)
+  # Use cred_fields list to create environment variable (e.g. DBCONNECT_ENDPOINT)
   env_variable <- tryCatch(
-    paste0("DBCONNECT_", toupper(fields[[key]])),
+    paste0("DBCONNECT_", toupper(cred_fields[[key]])),
     error=function(...) NULL
   )
   if (is.null(env_variable)) {
     return(value)
   }
 
-  # Get the environment variable
-  env_variable_value <- Sys.getenv(env_variable)
-  if (env_variable_value == "") {
-    return(value)
-  }
-
-  env_variable_value
+  # Get the environment variable, fallback on value
+  Sys.getenv(env_variable, value)
 }
 
 transform_creds <- function(creds) {


### PR DESCRIPTION
Fixes [CT-1281](https://datacamp.atlassian.net/browse/CT-1281)

- Allow us to overwrite the DB host by using an environment variable (e.g. `DBCONNECT_ENDPOINT`)