### PR TITLE
update hardcoded redshift host

### DIFF
--- a/R/dbconnectr.R
+++ b/R/dbconnectr.R
@@ -18,7 +18,7 @@ create_connection <- function(dbname = "main-app", cache = FALSE, cache_folder =
                               region = NULL,
                               ...) {
   creds <- get_creds(dbname, cache, cache_folder, profile = profile, region = region)
-  creds$host <- 'redshift-prod.datacamp.com'
+  creds$host <- 'datalake-redshift-public-prod.us-east-1.internal.datacamp.com'
 
   tryCatch(
     do.call(DBI::dbConnect, c(transform_creds(creds), list(...))),


### PR DESCRIPTION
This PR updates the redshift host to enable it to work under Wandera. 